### PR TITLE
Support latest webhooks integration url

### DIFF
--- a/src/assets/js/slacklink.js
+++ b/src/assets/js/slacklink.js
@@ -111,7 +111,7 @@ function post(){
 			$.ajax({
 
 				type: 'POST',
-				url: 'https://' + domain + '/services/hooks/incoming-webhook?token=' + apitoken,
+				url: 'https://hooks.slack.com/services/' + apitoken,
 				data: JSON.stringify(payload)
 
 			}).always(function() {


### PR DESCRIPTION
This appears to work. Likely it is unnecessary to have the domain option field, but I did not remove that with this commit.
